### PR TITLE
remove menu items that are not needed

### DIFF
--- a/mentorient/Views/Shared/_Layout.cshtml
+++ b/mentorient/Views/Shared/_Layout.cshtml
@@ -31,8 +31,6 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
                     <li><a asp-area="" asp-controller="Home" asp-action="Index">Home</a></li>
-                    <li><a asp-area="" asp-controller="Home" asp-action="About">About</a></li>
-                    <li><a asp-area="" asp-controller="Home" asp-action="Contact">Contact</a></li>
                     <li><a asp-area="" asp-controller="Tenants" asp-action="Index">Tenants</a></li>
                 </ul>
                 @await Html.PartialAsync("_LoginPartial")


### PR DESCRIPTION
removed the about and contact tab from the menu; we do not need it right now. 