### PR TITLE
Issues/#8_Tenants_In_Correspondence_To_User

### DIFF
--- a/mentorient/Controllers/TenantsController.cs
+++ b/mentorient/Controllers/TenantsController.cs
@@ -8,6 +8,7 @@ using mentorient.Models;
 using mentorient.Models.ViewModels;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace mentorient.Controllers
 {
@@ -26,8 +27,10 @@ namespace mentorient.Controllers
 
         public IActionResult Index()
         {
-            var loggedInUser = _userManager.GetUserId(User);
-            var tenants = _context.Tenants.ToList().Where(usr => usr.OwnerId == loggedInUser);
+            var userId = _userManager.GetUserId(User);
+            var tenants = _context.Users.Include(usr => usr.Tenants)
+                .Single(usr => usr.Id == userId)
+                .Tenants;
             
             return View(tenants);
         }
@@ -40,8 +43,8 @@ namespace mentorient.Controllers
         public IActionResult Save(Tenant tenant)
         {
 
-            tenant.OwnerId = _userManager.GetUserId(User);
-
+            var userId = _userManager.GetUserId(User);
+            _context.Users.Single(usr => usr.Id == userId).Tenants.Add(tenant);
             _context.Tenants.Add(tenant);
             _context.SaveChanges();
 

--- a/mentorient/Data/Migrations/20180111194759_SpecifyOwnerRelationshipOnlyOnApplicationUser.Designer.cs
+++ b/mentorient/Data/Migrations/20180111194759_SpecifyOwnerRelationshipOnlyOnApplicationUser.Designer.cs
@@ -11,9 +11,10 @@ using System;
 namespace mentorient.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180111194759_SpecifyOwnerRelationshipOnlyOnApplicationUser")]
+    partial class SpecifyOwnerRelationshipOnlyOnApplicationUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/mentorient/Data/Migrations/20180111194759_SpecifyOwnerRelationshipOnlyOnApplicationUser.cs
+++ b/mentorient/Data/Migrations/20180111194759_SpecifyOwnerRelationshipOnlyOnApplicationUser.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace mentorient.Data.Migrations
+{
+    public partial class SpecifyOwnerRelationshipOnlyOnApplicationUser : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OwnerId",
+                table: "Tenants");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OwnerId",
+                table: "Tenants",
+                nullable: true);
+        }
+    }
+}

--- a/mentorient/Models/Tenant.cs
+++ b/mentorient/Models/Tenant.cs
@@ -20,7 +20,5 @@ namespace mentorient.Models
         public string ZipCode { get; set; }
         public string State { get; set; }
         public string Country { get; set; }
-        public string OwnerId { get; set; }
-
     }
 }


### PR DESCRIPTION
Ties the tenant to the User who added them based on the already existing ForeignKey of ApplicationUserId. Removes the unneeded OwnerId on Tenant.

Populates the index view based on signed in User