### PR TITLE
First name claim and show in header #74

### DIFF
--- a/mentorient/Authorization/ClaimsPrincipalExtension.cs
+++ b/mentorient/Authorization/ClaimsPrincipalExtension.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace mentorient.Authorization
+{
+    public static class ClaimsPrincipalExtension
+    {
+        public static string GetFirstName(this ClaimsPrincipal principal)
+        {
+            var firstName = principal.Claims.SingleOrDefault(c => c.Type == MentorientClaimTypes.FirstName)?.Value;
+            return firstName;
+        }
+    }
+}

--- a/mentorient/Authorization/MentorientClaimTypes.cs
+++ b/mentorient/Authorization/MentorientClaimTypes.cs
@@ -1,0 +1,7 @@
+namespace mentorient.Authorization
+{
+   public class MentorientClaimTypes
+   {
+      public const string FirstName = "urn:mentorient:firstname";
+   }
+}

--- a/mentorient/Controllers/AccountController.cs
+++ b/mentorient/Controllers/AccountController.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Options;
 using mentorient.Models;
 using mentorient.Models.AccountViewModels;
 using mentorient.Services;
+using mentorient.Authorization;
 
 namespace mentorient.Controllers
 {
@@ -235,6 +236,8 @@ namespace mentorient.Controllers
                     var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                     var callbackUrl = Url.EmailConfirmationLink(user.Id, code, Request.Scheme);
                     await _emailSender.SendEmailConfirmationAsync(model.Email, callbackUrl);
+
+                    await _userManager.AddClaimAsync(user, new Claim(MentorientClaimTypes.FirstName, user.FirstName));
 
                     await _signInManager.SignInAsync(user, isPersistent: false);
                     _logger.LogInformation("User created a new account with password.");

--- a/mentorient/Controllers/ManageController.cs
+++ b/mentorient/Controllers/ManageController.cs
@@ -105,14 +105,19 @@ namespace mentorient.Controllers
                 }
             }
 
-            if (model.FirstName != user.FirstName || model.LastName != user.LastName)
+            var firstNameChanged = model.FirstName != user.FirstName;
+
+            if (firstNameChanged || model.LastName != user.LastName)
             {
                 user.FirstName = model.FirstName;
                 user.LastName = model.LastName;
 
-                await _userManager.ReplaceClaimAsync(user, 
-                    User.FindFirst(c => c.Type == MentorientClaimTypes.FirstName), 
-                    new Claim(MentorientClaimTypes.FirstName, user.FirstName));
+                if (firstNameChanged)
+                {
+                    await _userManager.ReplaceClaimAsync(user,
+                            User.FindFirst(c => c.Type == MentorientClaimTypes.FirstName),
+                            new Claim(MentorientClaimTypes.FirstName, user.FirstName));
+                }
 
                 var updateUserResult = await _userManager.UpdateAsync(user);
                 if (!updateUserResult.Succeeded)
@@ -120,7 +125,10 @@ namespace mentorient.Controllers
                     throw new ApplicationException($"Unexpected error occurred setting first and last name for user with ID '{user.Id}'.");
                 }
 
-                await _signInManager.RefreshSignInAsync(user);
+                if (firstNameChanged)
+                {
+                    await _signInManager.RefreshSignInAsync(user);
+                }
             }
 
             StatusMessage = "Your profile has been updated";

--- a/mentorient/Controllers/ManageController.cs
+++ b/mentorient/Controllers/ManageController.cs
@@ -13,6 +13,8 @@ using Microsoft.Extensions.Options;
 using mentorient.Models;
 using mentorient.Models.ManageViewModels;
 using mentorient.Services;
+using mentorient.Authorization;
+using System.Security.Claims;
 
 namespace mentorient.Controllers
 {
@@ -107,11 +109,18 @@ namespace mentorient.Controllers
             {
                 user.FirstName = model.FirstName;
                 user.LastName = model.LastName;
+
+                await _userManager.ReplaceClaimAsync(user, 
+                    User.FindFirst(c => c.Type == MentorientClaimTypes.FirstName), 
+                    new Claim(MentorientClaimTypes.FirstName, user.FirstName));
+
                 var updateUserResult = await _userManager.UpdateAsync(user);
                 if (!updateUserResult.Succeeded)
                 {
                     throw new ApplicationException($"Unexpected error occurred setting first and last name for user with ID '{user.Id}'.");
                 }
+
+                await _signInManager.RefreshSignInAsync(user);
             }
 
             StatusMessage = "Your profile has been updated";

--- a/mentorient/Views/Shared/_LoginPartial.cshtml
+++ b/mentorient/Views/Shared/_LoginPartial.cshtml
@@ -1,5 +1,6 @@
 @using Microsoft.AspNetCore.Identity
 @using mentorient.Models
+@using mentorient.Authorization
 
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
@@ -9,7 +10,7 @@
     <form asp-area="" asp-controller="Account" asp-action="Logout" method="post" id="logoutForm" class="navbar-right">
         <ul class="nav navbar-nav navbar-right">
             <li>
-                <a asp-area="" asp-controller="Manage" asp-action="Index" title="Manage">Hello @UserManager.GetUserName(User)!</a>
+                <a asp-area="" asp-controller="Manage" asp-action="Index" title="Manage">Hello @User.GetFirstName()!</a>
             </li>
             <li>
                 <button type="submit" class="btn btn-link navbar-btn navbar-link">Log out</button>


### PR DESCRIPTION
On user registration new claim will be created (FirstName). This claim is saved in the table `AspNetUserClaims`.
If First Name is changed on the profile page, claim will be updated and cookie.
Extension method added to read First Name from claims. 