### PR TITLE
Add fallback if first name doesn't exists #88

### DIFF
--- a/mentorient/Controllers/ManageController.cs
+++ b/mentorient/Controllers/ManageController.cs
@@ -114,9 +114,13 @@ namespace mentorient.Controllers
 
                 if (firstNameChanged)
                 {
-                    await _userManager.ReplaceClaimAsync(user,
+                    if (User.HasClaim(c => c.Type == MentorientClaimTypes.FirstName)) {
+                        await _userManager.ReplaceClaimAsync(user,
                             User.FindFirst(c => c.Type == MentorientClaimTypes.FirstName),
                             new Claim(MentorientClaimTypes.FirstName, user.FirstName));
+                    } else {
+                        await _userManager.AddClaimAsync(user, new Claim(MentorientClaimTypes.FirstName, user.FirstName));
+                    }
                 }
 
                 var updateUserResult = await _userManager.UpdateAsync(user);

--- a/mentorient/Views/Shared/_LoginPartial.cshtml
+++ b/mentorient/Views/Shared/_LoginPartial.cshtml
@@ -10,7 +10,7 @@
     <form asp-area="" asp-controller="Account" asp-action="Logout" method="post" id="logoutForm" class="navbar-right">
         <ul class="nav navbar-nav navbar-right">
             <li>
-                <a asp-area="" asp-controller="Manage" asp-action="Index" title="Manage">Hello @User.GetFirstName()!</a>
+                <a asp-area="" asp-controller="Manage" asp-action="Index" title="Manage">Hello @(User.GetFirstName() ?? UserManager.GetUserName(User))!</a>
             </li>
             <li>
                 <button type="submit" class="btn btn-link navbar-btn navbar-link">Log out</button>


### PR DESCRIPTION
Includes two fullbacks:
1. User is already created by claim doesn't exists in db. On update of the first name the claim will be created; if exists it will be replaced.
2. If first name claim is not in db, header salutation will fallback to username.  