### PR TITLE
Add simple home controller #26

### DIFF
--- a/mentorient/Api/Controllers/HomeController.cs
+++ b/mentorient/Api/Controllers/HomeController.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace mentorient.Api.Controllers
+{
+   [AllowAnonymous]
+   [Produces("application/json")]
+   [Route("api/Home")]
+   public class HomeController : Controller
+   {
+      [HttpGet]
+      public string Get()
+      {
+         return string.Empty;
+      }
+   }
+}


### PR DESCRIPTION
Just a simple controller which should be possible to call from front-end with `api/home`.
The name is Home, do we want other name?
Added in separate folder to be easier to find?